### PR TITLE
Add support for the case when claims contain lists

### DIFF
--- a/app/JWTBearer.py
+++ b/app/JWTBearer.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 
 from fastapi import HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -18,7 +18,7 @@ class JWKS(BaseModel):
 class JWTAuthorizationCredentials(BaseModel):
     jwt_token: str
     header: Dict[str, str]
-    claims: Dict[str, str]
+    claims: Dict[str, Union[str, List[str]]]
     signature: str
     message: str
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -25,4 +25,4 @@ async def get_current_user(
     try:
         return credentials.claims["username"]
     except KeyError:
-        HTTPException(status_code=HTTP_403_FORBIDDEN, detail="Username missing")
+        raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail="Username missing")


### PR DESCRIPTION
Add support for the case when claims contain lists of values, e.g. 
somekey='yes'
cognito:groups=['a','b','c']

Without this change I get a validation error from pydantic because the claims do not conform to the type defined in JWTAuthorizationCredentials. With the change both cases work. 